### PR TITLE
[FAU-376] Apply max-height rule per filter inside the advanced filters

### DIFF
--- a/resources/scss/components/search/filters/_filter-dropdown.scss
+++ b/resources/scss/components/search/filters/_filter-dropdown.scss
@@ -181,11 +181,6 @@
 				&::before {
 					top: 0;
 				}
-
-				.c-filter-choices {
-					max-height: unset;
-					overflow: unset;
-				}
 			}
 		}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Style update


**What is the current behavior?** (You can also link to an open issue here)
[Discussion](https://inpsyde.slack.com/archives/C045KFJ9MB5/p1718197469868729?thread_ts=1718194585.111219&cid=C045KFJ9MB5): the height of filters inside the advanced filters is not limited.


**What is the new behavior (if this is a feature change)?**
Removed the specific `max-height` rule for filters within the advanced filters. Now, the height is limited to 410px.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
