### PR TITLE
[FAU-376] Synchronize child terms for degree and admission requirement taxonomies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -411,12 +411,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/RRZE-Webteam/FAU-Studium-Common.git",
-                "reference": "fc1f347cd46f7cca7588c8a5df274b1426dd77d2"
+                "reference": "d83e8ea07501f8ab93d52fd2de7c44020751ec1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/fc1f347cd46f7cca7588c8a5df274b1426dd77d2",
-                "reference": "fc1f347cd46f7cca7588c8a5df274b1426dd77d2",
+                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/d83e8ea07501f8ab93d52fd2de7c44020751ec1d",
+                "reference": "d83e8ea07501f8ab93d52fd2de7c44020751ec1d",
                 "shasum": ""
             },
             "require": {
@@ -489,7 +489,7 @@
                 "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/dev",
                 "issues": "https://github.com/RRZE-Webteam/FAU-Studium-Common/issues"
             },
-            "time": "2024-07-03T10:40:43+00:00"
+            "time": "2024-07-16T06:54:30+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4339,16 +4339,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.24.0",
+            "version": "5.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "462c80e31c34e58cc4f750c656be3927e80e550e"
+                "reference": "01a8eb06b9e9cc6cfb6a320bf9fb14331919d505"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/462c80e31c34e58cc4f750c656be3927e80e550e",
-                "reference": "462c80e31c34e58cc4f750c656be3927e80e550e",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/01a8eb06b9e9cc6cfb6a320bf9fb14331919d505",
+                "reference": "01a8eb06b9e9cc6cfb6a320bf9fb14331919d505",
                 "shasum": ""
             },
             "require": {
@@ -4445,7 +4445,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2024-05-01T19:32:08+00:00"
+            "time": "2024-06-16T15:08:35+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -50,15 +50,6 @@
       <code><![CDATA[!$collection->nextPage()]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
-  <file src="src/Infrastructure/Search/FilterableTermsUpdater.php">
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[!$remoteTermId]]></code>
-      <code><![CDATA[!$termId]]></code>
-      <code><![CDATA[$newTermId]]></code>
-      <code><![CDATA[$newTermId]]></code>
-      <code><![CDATA[$newTermId]]></code>
-    </RiskyTruthyFalsyComparison>
-  </file>
   <file src="src/Infrastructure/Shortcode/ShortcodeAttributesNormalizer.php">
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[!$callable]]></code>

--- a/src/Infrastructure/Filter/FilterViewFactory.php
+++ b/src/Infrastructure/Filter/FilterViewFactory.php
@@ -236,15 +236,6 @@ final class FilterViewFactory
                 ),
                 AdmissionRequirementTypeFilter::FREE,
             ),
-            new Option(
-                AdmissionRequirementTypeFilter::KEY,
-                _x(
-                    'Admission free with restriction',
-                    'backoffice: Filter label',
-                    'fau-degree-program-output',
-                ),
-                AdmissionRequirementTypeFilter::FREE_WITH_RESTRICTION,
-            ),
         ];
     }
 

--- a/src/Infrastructure/Search/FilterableTermsUpdater.php
+++ b/src/Infrastructure/Search/FilterableTermsUpdater.php
@@ -335,10 +335,11 @@ final class FilterableTermsUpdater
         array &$taxonomyCache
     ): int {
 
-        if (!$flatProperty instanceof Degree && !$flatProperty instanceof AdmissionRequirement) {
+        if (!$this->isHierarchicalProperty($flatProperty)) {
             return 0;
         }
 
+        /** @var AdmissionRequirement|Degree $flatProperty */
         $parentProperty = $flatProperty->parent();
 
         if (is_null($parentProperty)) {
@@ -376,11 +377,12 @@ final class FilterableTermsUpdater
         $properties = [];
 
         foreach ($flatProperties as $flatProperty) {
-            if (!$flatProperty instanceof Degree && !$flatProperty instanceof AdmissionRequirement) {
+            if (!$this->isHierarchicalProperty($flatProperty)) {
                 $properties[] = $flatProperty;
                 continue;
             }
 
+            /** @var AdmissionRequirement|Degree $flatProperty */
             $sequence = [$flatProperty];
             $parent = $flatProperty->parent();
 
@@ -395,15 +397,11 @@ final class FilterableTermsUpdater
         return $properties;
     }
 
-    private function retrieveFirstLevelTerm(Degree|AdmissionRequirement $structure): Degree|AdmissionRequirement
-    {
-        $parent = $structure->parent();
-        while ($parent) {
-            $structure = $parent;
-            $parent = $structure->parent();
-        }
+    private function isHierarchicalProperty(
+        MultilingualString|MultilingualLink|AdmissionRequirement|Degree $flatProperty
+    ): bool {
 
-        return $structure;
+        return $flatProperty instanceof Degree || $flatProperty instanceof AdmissionRequirement;
     }
 
     private function createTerm(TermData $termData): ?int

--- a/src/Infrastructure/Search/TermData.php
+++ b/src/Infrastructure/Search/TermData.php
@@ -50,7 +50,6 @@ final class TermData
 
     public function termId(): int
     {
-
         return $this->termId;
     }
 

--- a/src/Infrastructure/Search/TermData.php
+++ b/src/Infrastructure/Search/TermData.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fau\DegreeProgram\Output\Infrastructure\Search;
+
+use Fau\DegreeProgram\Common\Domain\MultilingualString;
+
+/**
+ * @psalm-type TermData = array{
+ *     taxonomy: string,
+ *     name: MultilingualString,
+ *     slug: string,
+ *     term_id: int,
+ *     remote_term_id: int,
+ *     parent_term_id: int
+ * }
+ */
+final class TermData
+{
+    private function __construct(
+        private string $taxonomy,
+        private MultilingualString $name,
+        private string $slug,
+        private int $termId,
+        private int $remoteTermId,
+        private int $parentTermId
+    ) {
+    }
+
+    /**
+     * @psalm-param TermData $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['taxonomy'],
+            $data['name'],
+            $data['slug'],
+            $data['term_id'],
+            $data['remote_term_id'],
+            $data['parent_term_id'],
+        );
+    }
+
+    public function slug(): string
+    {
+        return $this->slug;
+    }
+
+    public function termId(): int
+    {
+
+        return $this->termId;
+    }
+
+    public function remoteTermId(): int
+    {
+        return $this->remoteTermId;
+    }
+
+    public function taxonomy(): string
+    {
+        return $this->taxonomy;
+    }
+
+    public function name(): MultilingualString
+    {
+        return $this->name;
+    }
+
+    public function parentTermId(): int
+    {
+        return $this->parentTermId;
+    }
+}

--- a/src/Infrastructure/Shortcode/ShortcodeAttributesNormalizer.php
+++ b/src/Infrastructure/Shortcode/ShortcodeAttributesNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fau\DegreeProgram\Output\Infrastructure\Shortcode;
 
+use Fau\DegreeProgram\Common\Application\Filter\AdmissionRequirementTypeFilter;
 use Fau\DegreeProgram\Common\Application\Filter\Filter;
 use Fau\DegreeProgram\Common\Application\Filter\FilterFactory;
 use Fau\DegreeProgram\Common\Domain\MultilingualString;
@@ -110,11 +111,15 @@ final class ShortcodeAttributesNormalizer
         return $attributes;
     }
 
-    /** @return array<int> */
+    /** @return array<int|string> */
     private function preAppliedFilter(string $filterName, mixed $filterValue): array
     {
         if (!is_string($filterValue)) {
             return [];
+        }
+
+        if ($filterName === AdmissionRequirementTypeFilter::KEY) {
+            return explode(',', $filterValue);
         }
 
         return array_filter(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-376


**What is the new behavior (if this is a feature change)?**
Child terms are synchronized for the Degree and Admission Requirement taxonomies. Additionally, slugs for the Admission Requirement taxonomies are updated to support the pre-filtered feature.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Psaml issues should be fixed after merge https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/15 