### PR TITLE
[FAU-434] Correctly assign campo keys to multiple terms within degree program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Implemented synchronization for campo keys of child terms.
+
 ## [2.0.0] - 2024-07-24
 
 ### Added

--- a/composer.lock
+++ b/composer.lock
@@ -411,12 +411,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/RRZE-Webteam/FAU-Studium-Common.git",
-                "reference": "059457f63e219f1fd3a0d8b3d3b063d7ea2b40db"
+                "reference": "2314da111571d795a3f3d3dbe194680737a26e07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/059457f63e219f1fd3a0d8b3d3b063d7ea2b40db",
-                "reference": "059457f63e219f1fd3a0d8b3d3b063d7ea2b40db",
+                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/2314da111571d795a3f3d3dbe194680737a26e07",
+                "reference": "2314da111571d795a3f3d3dbe194680737a26e07",
                 "shasum": ""
             },
             "require": {
@@ -438,6 +438,7 @@
             "suggest": {
                 "inpsyde/modularity": "Modular PSR-11 implementation for WordPress Plugins, Themes or Libraries"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -488,7 +489,7 @@
                 "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/main",
                 "issues": "https://github.com/RRZE-Webteam/FAU-Studium-Common/issues"
             },
-            "time": "2024-09-04T10:07:44+00:00"
+            "time": "2024-09-04T13:20:56+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Infrastructure/Search/FilterableTermsUpdater.php
+++ b/src/Infrastructure/Search/FilterableTermsUpdater.php
@@ -544,16 +544,16 @@ final class FilterableTermsUpdater
 
     private function maybeUpdateCampoKeys(DegreeProgramViewRaw $rawView, string $taxonomy, array $terms): void
     {
+        $campoKeys = $rawView->campoKeys()->asArray();
+        $campoKeyType = CampoKeysRepository::TAXONOMY_TO_CAMPO_KEY_MAP[$taxonomy] ?? '';
+        $taxonomyCampoKeys = $campoKeys[$campoKeyType] ?? null;
+
+        if (!is_array($taxonomyCampoKeys)) {
+            return;
+        }
+
         /** @var TermData $term */
         foreach ($terms as $term) {
-            $campoKeys = $rawView->campoKeys()->asArray();
-            $campoKeyType = CampoKeysRepository::TAXONOMY_TO_CAMPO_KEY_MAP[$taxonomy] ?? '';
-            $taxonomyCampoKeys = $campoKeys[$campoKeyType] ?? null;
-
-            if (!is_array($taxonomyCampoKeys)) {
-                continue;
-            }
-
             $termCampoKey = $taxonomyCampoKeys[$term->remoteTermId()] ?? null;
 
             if (is_null($termCampoKey)) {

--- a/src/Infrastructure/Search/FilterableTermsUpdater.php
+++ b/src/Infrastructure/Search/FilterableTermsUpdater.php
@@ -141,19 +141,19 @@ final class FilterableTermsUpdater
         string $taxonomy,
         MultilingualString|MultilingualList|MultilingualLink|MultilingualLinks|Degree|AdmissionRequirement $property
     ): void {
-
-        $termIds = $this->maybeCreateTerms($taxonomy, $property);
+        /** @var array<int, TermData> $terms */
+        $terms = $this->maybeCreateTerms($taxonomy, $property);
         wp_set_object_terms(
             $rawView->id()->asInt(),
-            $termIds,
+            array_keys($terms),
             $taxonomy
         );
 
-        if (! isset($termIds[0])) {
+        if (!$terms) {
             return;
         }
 
-        $this->maybeUpdateCampoKeys($rawView, $taxonomy, (int) $termIds[0]);
+        $this->maybeUpdateCampoKeys($rawView, $taxonomy, $terms);
     }
 
     private function isValidPostId(int $postId): bool
@@ -179,6 +179,8 @@ final class FilterableTermsUpdater
      * phpcs:disable Inpsyde.CodeQuality.FunctionLength.TooLong
      *
      * Refactoring could decrease performance.
+     *
+     * @return array<int, TermData>
      */
     private function maybeCreateTerms(
         string $taxonomy,
@@ -225,7 +227,7 @@ final class FilterableTermsUpdater
 
             if ($termData->termId()) {
                 // Term was persisted already
-                $result[] = $termData->termId();
+                $result[$termData->termId()] = $termData;
                 $this->updateTerm($termData);
                 continue;
             }
@@ -233,7 +235,7 @@ final class FilterableTermsUpdater
             $termId = $this->createTerm($termData);
 
             if (is_int($termId)) {
-                $result[] = $termId;
+                $result[$termId] = $termData;
                 $taxonomiesCache[$taxonomy][$termId] = [
                     self::TAXONOMIES_CACHE_NAME_PROPERTY => $termData->name()->inGerman(),
                     self::TAXONOMIES_CACHE_ORIGINAL_ID_PROPERTY => $termData->remoteTermId(),
@@ -540,16 +542,25 @@ final class FilterableTermsUpdater
         return null;
     }
 
-    private function maybeUpdateCampoKeys(DegreeProgramViewRaw $rawView, string $taxonomy, int $termId): void
+    private function maybeUpdateCampoKeys(DegreeProgramViewRaw $rawView, string $taxonomy, array $terms): void
     {
-        $campoKeys = $rawView->campoKeys()->asArray();
-        $campoKeyType = CampoKeysRepository::TAXONOMY_TO_CAMPO_KEY_MAP[$taxonomy] ?? '';
-        $campoKey = $campoKeys[$campoKeyType] ?? null;
+        /** @var TermData $term */
+        foreach ($terms as $term) {
+            $campoKeys = $rawView->campoKeys()->asArray();
+            $campoKeyType = CampoKeysRepository::TAXONOMY_TO_CAMPO_KEY_MAP[$taxonomy] ?? '';
+            $taxonomyCampoKeys = $campoKeys[$campoKeyType] ?? null;
 
-        if (is_null($campoKey)) {
-            return;
+            if (!is_array($taxonomyCampoKeys)) {
+                continue;
+            }
+
+            $termCampoKey = $taxonomyCampoKeys[$term->remoteTermId()] ?? null;
+
+            if (is_null($termCampoKey)) {
+                continue;
+            }
+
+            update_term_meta($term->termId(), CampoKeysRepository::CAMPO_KEY_TERM_META_KEY, $termCampoKey);
         }
-
-        update_term_meta($termId, CampoKeysRepository::CAMPO_KEY_TERM_META_KEY, $campoKey);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)

https://inpsyde.atlassian.net/browse/FAU-434

Currently we have only one campo key per taxonomy in the degree program data, even if degree program has a few terms with  different campo keys. 

**What is the new behavior (if this is a feature change)?**

The new logic presented in related [PR](https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/17), includes campo keys from all related terms to degree program data. And in this PR, we update the current implementation to handle an array of campo keys instead of a single string, as was previously done.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/17