### PR TITLE
[FAU-443] Synchronize parent and child terms using the MultilingualLink representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add synchronization of 'German language skills for international students' child terms to consuming websites.
+
 ## [2.1.0] - 2024-09-06
 
 ### Added

--- a/composer.lock
+++ b/composer.lock
@@ -401,12 +401,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/RRZE-Webteam/FAU-Studium-Common.git",
-                "reference": "2314da111571d795a3f3d3dbe194680737a26e07"
+                "reference": "9d164cfcdb8ff80950fbf07b9a9e8629342d7cac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/2314da111571d795a3f3d3dbe194680737a26e07",
-                "reference": "2314da111571d795a3f3d3dbe194680737a26e07",
+                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/9d164cfcdb8ff80950fbf07b9a9e8629342d7cac",
+                "reference": "9d164cfcdb8ff80950fbf07b9a9e8629342d7cac",
                 "shasum": ""
             },
             "require": {
@@ -479,7 +479,7 @@
                 "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/main",
                 "issues": "https://github.com/RRZE-Webteam/FAU-Studium-Common/issues"
             },
-            "time": "2024-09-04T13:20:56+00:00"
+            "time": "2025-01-03T11:55:51+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/src/Infrastructure/Search/FilterableTermsUpdater.php
+++ b/src/Infrastructure/Search/FilterableTermsUpdater.php
@@ -403,11 +403,7 @@ final class FilterableTermsUpdater
         MultilingualString|MultilingualLink|AdmissionRequirement|Degree $flatProperty
     ): bool {
 
-        return in_array($flatProperty::class, [
-            Degree::class,
-            AdmissionRequirement::class,
-            MultilingualLink::class,
-        ], true);
+        return !$flatProperty instanceof MultilingualString;
     }
 
     private function createTerm(TermData $termData): ?int

--- a/src/Infrastructure/Search/FilterableTermsUpdater.php
+++ b/src/Infrastructure/Search/FilterableTermsUpdater.php
@@ -341,7 +341,7 @@ final class FilterableTermsUpdater
             return 0;
         }
 
-        /** @var AdmissionRequirement|Degree $flatProperty */
+        /** @var AdmissionRequirement|Degree|MultilingualLink $flatProperty */
         $parentProperty = $flatProperty->parent();
 
         if (is_null($parentProperty)) {
@@ -403,7 +403,11 @@ final class FilterableTermsUpdater
         MultilingualString|MultilingualLink|AdmissionRequirement|Degree $flatProperty
     ): bool {
 
-        return $flatProperty instanceof Degree || $flatProperty instanceof AdmissionRequirement;
+        return in_array($flatProperty::class, [
+            Degree::class,
+            AdmissionRequirement::class,
+            MultilingualLink::class,
+        ], true);
     }
 
     private function createTerm(TermData $termData): ?int


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-443


**What is the new behavior (if this is a feature change)?**
Added synchronization for 'German language skills for international students' child terms to consuming websites. This update likely extends to all taxonomies where terms are represented as `MultilingualLink`. 


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Related PR that introduces a `parent` in `MultilingualLink` property: https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/20

The Psalm issues should be resolved once the above PR is merged.