### PR TITLE
[FAU-449] Trigger search only when checkbox state changes

### DIFF
--- a/resources/ts/filters/filter-dropdown.ts
+++ b/resources/ts/filters/filter-dropdown.ts
@@ -1,51 +1,100 @@
 import submitForm from '../form/form-handler';
+import isReducedMotion from '../common/reduced-motion-detection';
 
 const DROPDOWN_SELECTOR = '.fau-dropdown';
 const DROPDOWN_TOGGLE_SELECTOR = '.fau-dropdown__toggle';
 const DROPDOWN_CONTENT_SELECTOR = '.fau-dropdown__content';
 const CLICKAWAY_WINDOW_WIDTH_THRESHOLD = 768; // close on click away only works on screen sizes above this value
 
-const closeDropDown = ( dropdown: HTMLElement ) => {
-	dropdown.setAttribute( 'aria-expanded', 'false' );
-	submitForm();
-};
+class Dropdown {
+	private dropdown: HTMLElement;
+	private toggle: HTMLElement;
+	private content: HTMLElement;
+	private checkboxes: HTMLInputElement[];
+	private initialState: boolean[] = [];
 
-const toggleDropdown = ( dropdown: HTMLElement ) => {
-	const isAriaExpanded = dropdown.getAttribute( 'aria-expanded' ) === 'true';
+	constructor( dropdown: HTMLElement ) {
+		this.dropdown = dropdown;
+		this.toggle = dropdown.querySelector( DROPDOWN_TOGGLE_SELECTOR )!;
+		this.content = dropdown.querySelector( DROPDOWN_CONTENT_SELECTOR )!;
+		this.checkboxes = Array.from(
+			this.content.querySelectorAll( 'input[type="checkbox"]' )
+		);
 
-	dropdown.setAttribute( 'aria-expanded', isAriaExpanded ? 'false' : 'true' );
-
-	if ( isAriaExpanded ) {
-		submitForm();
+		this.init();
 	}
-};
 
-const registerClickListeners = () => {
+	private recordInitialState() {
+		this.initialState = this.checkboxes.map(
+			( checkbox ) => checkbox.checked
+		);
+	}
+
+	private hasStateChanged(): boolean {
+		const currentState = this.checkboxes.map(
+			( checkbox ) => checkbox.checked
+		);
+
+		return ! this.initialState.every(
+			( value, index ) => value === currentState[ index ]
+		);
+	}
+
+	private close() {
+		this.dropdown.setAttribute( 'aria-expanded', 'false' );
+
+		if ( this.hasStateChanged() && isReducedMotion() ) {
+			submitForm();
+		}
+	}
+
+	private toggleDropdown() {
+		const isAriaExpanded =
+			this.dropdown.getAttribute( 'aria-expanded' ) === 'true';
+
+		if ( ! isAriaExpanded ) {
+			this.recordInitialState();
+		}
+
+		this.dropdown.setAttribute(
+			'aria-expanded',
+			isAriaExpanded ? 'false' : 'true'
+		);
+
+		if ( isAriaExpanded && this.hasStateChanged() && isReducedMotion() ) {
+			submitForm();
+		}
+	}
+
+	private handleBodyClick( event: MouseEvent ) {
+		const target = event.target as Node;
+
+		if ( this.toggle.contains( target ) ) {
+			this.toggleDropdown();
+			return;
+		}
+
+		if (
+			this.dropdown.getAttribute( 'aria-expanded' ) === 'true' &&
+			! this.dropdown.contains( target ) &&
+			window.innerWidth > CLICKAWAY_WINDOW_WIDTH_THRESHOLD
+		) {
+			this.close();
+		}
+	}
+
+	private init() {
+		document.body.addEventListener(
+			'click',
+			this.handleBodyClick.bind( this )
+		);
+	}
+}
+
+const registerDropdowns = () => {
 	document
 		.querySelectorAll< HTMLElement >( DROPDOWN_SELECTOR )
-		.forEach( ( dropdown ) => {
-			const toggle = dropdown.querySelector( DROPDOWN_TOGGLE_SELECTOR );
-			const content = dropdown.querySelector( DROPDOWN_CONTENT_SELECTOR );
-
-			if ( ! toggle || ! content ) {
-				return;
-			}
-
-			document.body.addEventListener( 'click', ( event ) => {
-				if ( toggle.contains( event.target as Node ) ) {
-					toggleDropdown( dropdown );
-					return;
-				}
-
-				if (
-					dropdown.getAttribute( 'aria-expanded' ) === 'true' &&
-					! dropdown.contains( event.target as Node ) &&
-					window.innerWidth > CLICKAWAY_WINDOW_WIDTH_THRESHOLD
-				) {
-					closeDropDown( dropdown );
-				}
-			} );
-		} );
+		.forEach( ( dropdown ) => new Dropdown( dropdown ) );
 };
 
-registerClickListeners();
+registerDropdowns();

--- a/resources/ts/filters/filter-dropdown.ts
+++ b/resources/ts/filters/filter-dropdown.ts
@@ -35,8 +35,8 @@ class Dropdown {
 			( checkbox ) => checkbox.checked
 		);
 
-		return ! this.initialState.every(
-			( value, index ) => value === currentState[ index ]
+		return this.initialState.some(
+			( value, index ) => value !== currentState[ index ]
 		);
 	}
 

--- a/resources/ts/filters/filter-dropdown.ts
+++ b/resources/ts/filters/filter-dropdown.ts
@@ -61,7 +61,7 @@ class Dropdown {
 			isAriaExpanded ? 'false' : 'true'
 		);
 
-		if ( isAriaExpanded && this.hasStateChanged() && isReducedMotion() ) {
+		if ( isAriaExpanded && isReducedMotion() && this.hasStateChanged() ) {
 			submitForm();
 		}
 	}

--- a/resources/ts/filters/filters-handler.ts
+++ b/resources/ts/filters/filters-handler.ts
@@ -5,7 +5,7 @@ import updateFiltersCount from './filters-count';
 import submitForm from '../form/form-handler';
 import { updateDegreeProgramOverviewDataset } from '../degree-program-overview/degree-program-overview';
 
-export const FILTER_SELECTOR = '.c-filter-checkbox';
+const FILTER_SELECTOR = '.c-filter-checkbox';
 export const LANGUAGE_SKILLS_INPUT =
 	'german-language-skills-for-international-students';
 

--- a/resources/ts/filters/filters-handler.ts
+++ b/resources/ts/filters/filters-handler.ts
@@ -5,7 +5,7 @@ import updateFiltersCount from './filters-count';
 import submitForm from '../form/form-handler';
 import { updateDegreeProgramOverviewDataset } from '../degree-program-overview/degree-program-overview';
 
-const FILTER_SELECTOR = '.c-filter-checkbox';
+export const FILTER_SELECTOR = '.c-filter-checkbox';
 export const LANGUAGE_SKILLS_INPUT =
 	'german-language-skills-for-international-students';
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-449


**What is the new behavior (if this is a feature change)?**
This PR improves the behavior of filter dropdowns to ensure that searches are triggered only under specific conditions:

- When Reduced Motion is disabled, closing any filter dropdown does not trigger a search.
- When Reduced Motion is enabled, the system triggers a search only if one or more filter parameters inside the dropdown are changed before closing.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
