### PR TITLE
[FAU-452] Correct loading template translations

### DIFF
--- a/src/Infrastructure/Component/DegreeProgramsSearch.php
+++ b/src/Infrastructure/Component/DegreeProgramsSearch.php
@@ -78,8 +78,7 @@ final class DegreeProgramsSearch implements RenderableComponent
         $localeHelper = $localeHelper->withLocale(
             $localeHelper->localeFromLanguageCode($attributes['lang'])
         );
-
-        add_filter('locale', [$localeHelper, 'filterLocale']);
+        switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
 
         $filterViews = $this->buildFilterViews($attributes);
         [$filters, $advancedFilters] = $this->splitFilterViews(...$filterViews);
@@ -103,7 +102,8 @@ final class DegreeProgramsSearch implements RenderableComponent
                 'preAppliedFilters' =>  $attributes['pre_applied_filters'],
             ],
         );
-        remove_filter('locale', [$localeHelper, 'filterLocale']);
+
+        restore_previous_locale();
 
         return $html;
     }

--- a/src/Infrastructure/Component/SingleDegreeProgram.php
+++ b/src/Infrastructure/Component/SingleDegreeProgram.php
@@ -91,7 +91,7 @@ final class SingleDegreeProgram implements RenderableComponent
             $localeHelper->localeFromLanguageCode($attributes['lang'])
         );
 
-        add_filter('locale', [$localeHelper, 'filterLocale']);
+        switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
         $html = $this->renderer->render(
             'single-degree-program-' . $attributes['format'],
             [
@@ -99,7 +99,7 @@ final class SingleDegreeProgram implements RenderableComponent
                 'className' => $attributes['className'],
             ]
         );
-        remove_filter('locale', [$localeHelper, 'filterLocale']);
+        restore_previous_locale();
 
         return $html;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-452
Initial [PR](https://github.com/inpsyde/fau-degree-program-output/pull/79/files) that introduces the `lang` parameter.


**What is the new behavior (if this is a feature change)?**
It seems tha `locale` filter is used early in the request lifecycle, before WordPress loads translation files. Adding this filter after translations have already been loaded does not reload or change the active locale in real-time. 
Since we need runtime translation switching, `switch_to_locale()` is the correct method.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Local testing is welcome 😄 