### PR TITLE
[FAU-452] Remove unused method

### DIFF
--- a/src/Infrastructure/Component/DegreeProgramsSearch.php
+++ b/src/Infrastructure/Component/DegreeProgramsSearch.php
@@ -78,8 +78,8 @@ final class DegreeProgramsSearch implements RenderableComponent
         $localeHelper = $localeHelper->withLocale(
             $localeHelper->localeFromLanguageCode($attributes['lang'])
         );
-        switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
 
+        switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
         $filterViews = $this->buildFilterViews($attributes);
         [$filters, $advancedFilters] = $this->splitFilterViews(...$filterViews);
 
@@ -102,7 +102,6 @@ final class DegreeProgramsSearch implements RenderableComponent
                 'preAppliedFilters' =>  $attributes['pre_applied_filters'],
             ],
         );
-
         restore_previous_locale();
 
         return $html;

--- a/src/Infrastructure/Rewrite/LocaleHelper.php
+++ b/src/Infrastructure/Rewrite/LocaleHelper.php
@@ -40,12 +40,4 @@ final class LocaleHelper
 
         return 'de_DE';
     }
-
-    /**
-     * @wp-hook locale
-     */
-    public function filterLocale(): string
-    {
-        return $this->locale;
-    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Chore


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-452

Follow up on #55, which removed usages of the `filterLocale()` method.


**What is the new behavior (if this is a feature change)?**
Remove the unused `filterLocale()` method.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Also did some pedantry alignment of empty lines.