### PR TITLE
[FAU-452] Support 'lang' parameter in the single degree program view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add "Also search in text" option to search form.
 - Support multi-word free text search.
 - Show keywords in single degree program details section.
+- Support the "lang" URL parameter to specify the language of a single degree program.
 
 ### Changed
 

--- a/composer.lock
+++ b/composer.lock
@@ -401,12 +401,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/RRZE-Webteam/FAU-Studium-Common.git",
-                "reference": "9d164cfcdb8ff80950fbf07b9a9e8629342d7cac"
+                "reference": "c58b1817ecf9331bc8a76f90fd12ff57c139d09e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/9d164cfcdb8ff80950fbf07b9a9e8629342d7cac",
-                "reference": "9d164cfcdb8ff80950fbf07b9a9e8629342d7cac",
+                "url": "https://api.github.com/repos/RRZE-Webteam/FAU-Studium-Common/zipball/c58b1817ecf9331bc8a76f90fd12ff57c139d09e",
+                "reference": "c58b1817ecf9331bc8a76f90fd12ff57c139d09e",
                 "shasum": ""
             },
             "require": {
@@ -479,7 +479,7 @@
                 "source": "https://github.com/RRZE-Webteam/FAU-Studium-Common/tree/main",
                 "issues": "https://github.com/RRZE-Webteam/FAU-Studium-Common/issues"
             },
-            "time": "2025-01-03T11:55:51+00:00"
+            "time": "2025-03-05T10:37:59+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/resources/ts/degree-program-overview/degree-program-overview.ts
+++ b/resources/ts/degree-program-overview/degree-program-overview.ts
@@ -15,11 +15,16 @@ const degreeProgramsOverview =
 		DEGREE_PROGRAMS_OVERVIEW_SELECTOR
 	);
 
+const isLocaleSwitched =
+	degreeProgramsSection?.getAttribute( 'data-locale-switched' ) || '';
+
 export const currentLanguage =
 	degreeProgramsSection?.getAttribute( 'lang' )?.substring( 0, 2 ) || 'de';
 
 const renderPrograms = ( programs: DegreeProgram[] ) => {
-	const output = programs.map( ( program ) => program.render() ).join( '' );
+	const output = programs
+		.map( ( program ) => program.render( isLocaleSwitched ) )
+		.join( '' );
 	degreeProgramsOverview?.insertAdjacentHTML( 'beforeend', output );
 };
 

--- a/resources/ts/degree-program-overview/degree-program.ts
+++ b/resources/ts/degree-program-overview/degree-program.ts
@@ -15,6 +15,7 @@ interface DegreeProgramData {
 	semester: string[];
 	admissionRequirements: string;
 	germanLanguageSkills: string;
+	lang: string;
 }
 
 export interface DegreeProgramApiData {
@@ -30,6 +31,7 @@ export interface DegreeProgramApiData {
 	teaser_image: { rendered: string };
 	admission_requirement_link: { name: string };
 	german_language_skills_for_international_students: { name: string };
+	lang: string;
 }
 
 interface DegreeProgram extends DegreeProgramData {}
@@ -45,6 +47,7 @@ class DegreeProgram {
 		location,
 		admissionRequirements,
 		germanLanguageSkills,
+		lang,
 	}: DegreeProgramData ) {
 		this.id = id;
 		this.image = image;
@@ -55,6 +58,7 @@ class DegreeProgram {
 		this.location = location;
 		this.admissionRequirements = admissionRequirements;
 		this.germanLanguageSkills = germanLanguageSkills;
+		this.lang = lang;
 	}
 
 	static createDegreeProgram( program: DegreeProgramApiData ): DegreeProgram {
@@ -69,7 +73,15 @@ class DegreeProgram {
 			admissionRequirements: program.admission_requirement_link?.name,
 			germanLanguageSkills:
 				program.german_language_skills_for_international_students.name,
+			lang: program.lang,
 		} );
+	}
+
+	generateURL(): string {
+		const urlParams = new URLSearchParams();
+		urlParams.append( 'lang', this.lang );
+
+		return `${ this.url }?${ urlParams.toString() }`;
 	}
 
 	render(): string {
@@ -79,9 +91,7 @@ class DegreeProgram {
 					${ this.image }
 				</div>
 				<div class="c-degree-program-preview__title">
-					<a class="c-degree-program-preview__link" href="${
-						this.url
-					}" rel="bookmark" aria-labelledby="degree-program-title-${
+					<a class="c-degree-program-preview__link" href="${ this.generateURL() }" rel="bookmark" aria-labelledby="degree-program-title-${
 						this.id
 					}"></a>
 					<div id="degree-program-title-${ this.id }">

--- a/resources/ts/degree-program-overview/degree-program.ts
+++ b/resources/ts/degree-program-overview/degree-program.ts
@@ -77,21 +77,24 @@ class DegreeProgram {
 		} );
 	}
 
-	generateURL(): string {
-		const urlParams = new URLSearchParams();
-		urlParams.append( 'lang', this.lang );
-
-		return `${ this.url }?${ urlParams.toString() }`;
+	urlWithLang(): string {
+		const url = new URL( this.url );
+		url.searchParams.set( 'lang', this.lang );
+		return url.toString();
 	}
 
-	render(): string {
+	render( isLocaleSwitched: string ): string {
 		return `
 			<li class="c-degree-program-preview">
 				<div class="c-degree-program-preview__teaser-image">
 					${ this.image }
 				</div>
 				<div class="c-degree-program-preview__title">
-					<a class="c-degree-program-preview__link" href="${ this.generateURL() }" rel="bookmark" aria-labelledby="degree-program-title-${
+					<a class="c-degree-program-preview__link" href="${
+						isLocaleSwitched === 'true'
+							? this.urlWithLang()
+							: this.url
+					}" rel="bookmark" aria-labelledby="degree-program-title-${
 						this.id
 					}"></a>
 					<div id="degree-program-title-${ this.id }">

--- a/src/Infrastructure/Component/DegreeProgramsSearch.php
+++ b/src/Infrastructure/Component/DegreeProgramsSearch.php
@@ -68,10 +68,7 @@ final class DegreeProgramsSearch implements RenderableComponent
     public function render(array $attributes = self::DEFAULT_ATTRIBUTES): string
     {
         $localeHelper = LocaleHelper::new();
-
         $requestLanguageCode = $this->currentRequest->languageCode();
-        $shouldSwitchLocale =
-            !empty($attributes['lang']) && $attributes['lang'] !== $requestLanguageCode;
 
         /** @var DegreeProgramsSearchAttributes $attributes */
         $attributes = wp_parse_args(
@@ -79,14 +76,17 @@ final class DegreeProgramsSearch implements RenderableComponent
             array_merge(self::DEFAULT_ATTRIBUTES, ['lang' => $requestLanguageCode])
         );
 
+        $language = $attributes['lang'];
+        $shouldSwitchLocale = $language !== $requestLanguageCode;
+
         $collection = $this->findCollection($attributes);
 
         $localeHelper = $localeHelper->withLocale(
-            $localeHelper->localeFromLanguageCode($attributes['lang'])
+            $localeHelper->localeFromLanguageCode($language)
         );
 
         if ($shouldSwitchLocale) {
-            switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
+            switch_to_locale($localeHelper->localeFromLanguageCode($language));
         }
 
         $filterViews = $this->buildFilterViews($attributes);

--- a/src/Infrastructure/Component/DegreeProgramsSearch.php
+++ b/src/Infrastructure/Component/DegreeProgramsSearch.php
@@ -68,7 +68,10 @@ final class DegreeProgramsSearch implements RenderableComponent
     public function render(array $attributes = self::DEFAULT_ATTRIBUTES): string
     {
         $localeHelper = LocaleHelper::new();
-        $attributes['lang'] = $attributes['lang'] ?? $this->currentRequest->languageCode();
+
+        $requestLanguageCode = $this->currentRequest->languageCode();
+        $needSwitchLocale = !empty($attributes['lang']) && $attributes['lang'] !== $requestLanguageCode;
+        $attributes['lang'] = $attributes['lang'] ?? $requestLanguageCode;
 
         /** @var DegreeProgramsSearchAttributes $attributes */
         $attributes = wp_parse_args($attributes, self::DEFAULT_ATTRIBUTES);
@@ -78,7 +81,10 @@ final class DegreeProgramsSearch implements RenderableComponent
         $localeHelper = $localeHelper->withLocale(
             $localeHelper->localeFromLanguageCode($attributes['lang'])
         );
-        switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
+
+        if ($needSwitchLocale) {
+            switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
+        }
 
         $filterViews = $this->buildFilterViews($attributes);
         [$filters, $advancedFilters] = $this->splitFilterViews(...$filterViews);
@@ -103,7 +109,9 @@ final class DegreeProgramsSearch implements RenderableComponent
             ],
         );
 
-        restore_previous_locale();
+        if ($needSwitchLocale) {
+            restore_previous_locale();
+        }
 
         return $html;
     }

--- a/src/Infrastructure/Component/DegreeProgramsSearch.php
+++ b/src/Infrastructure/Component/DegreeProgramsSearch.php
@@ -70,11 +70,14 @@ final class DegreeProgramsSearch implements RenderableComponent
         $localeHelper = LocaleHelper::new();
 
         $requestLanguageCode = $this->currentRequest->languageCode();
-        $needSwitchLocale = !empty($attributes['lang']) && $attributes['lang'] !== $requestLanguageCode;
-        $attributes['lang'] = $attributes['lang'] ?? $requestLanguageCode;
+        $shouldSwitchLocale =
+            !empty($attributes['lang']) && $attributes['lang'] !== $requestLanguageCode;
 
         /** @var DegreeProgramsSearchAttributes $attributes */
-        $attributes = wp_parse_args($attributes, self::DEFAULT_ATTRIBUTES);
+        $attributes = wp_parse_args(
+            $attributes,
+            array_merge(self::DEFAULT_ATTRIBUTES, ['lang' => $requestLanguageCode])
+        );
 
         $collection = $this->findCollection($attributes);
 
@@ -82,7 +85,7 @@ final class DegreeProgramsSearch implements RenderableComponent
             $localeHelper->localeFromLanguageCode($attributes['lang'])
         );
 
-        if ($needSwitchLocale) {
+        if ($shouldSwitchLocale) {
             switch_to_locale($localeHelper->localeFromLanguageCode($attributes['lang']));
         }
 
@@ -109,7 +112,7 @@ final class DegreeProgramsSearch implements RenderableComponent
             ],
         );
 
-        if ($needSwitchLocale) {
+        if ($shouldSwitchLocale) {
             restore_previous_locale();
         }
 

--- a/src/Infrastructure/Rewrite/CurrentRequest.php
+++ b/src/Infrastructure/Rewrite/CurrentRequest.php
@@ -29,6 +29,7 @@ final class CurrentRequest
     public const ORDER_BY_QUERY_PARAM = 'order_by';
     public const ORDER_QUERY_PARAM = 'order';
     public const OUTPUT_MODE_QUERY_PARAM = 'output';
+    public const LANGUAGE_PARAM = 'lang';
 
     private const ARRAY_OF_IDS = [
         'filter' => FILTER_VALIDATE_INT,
@@ -63,10 +64,34 @@ final class CurrentRequest
      */
     public function languageCode(): string
     {
-        $languageCode = explode('_', get_locale())[0] ?? '';
-        return in_array($languageCode, [MultilingualString::DE, MultilingualString::EN], true)
-            ? $languageCode
-            : MultilingualString::DE;
+        $languageFromQuery = (string) filter_input(
+            INPUT_GET,
+            self::LANGUAGE_PARAM,
+            FILTER_SANITIZE_SPECIAL_CHARS
+        );
+
+        if ($this->isValidLanguage($languageFromQuery)) {
+            /** @psalm-var LanguageCodes $languageFromQuery */
+            return $languageFromQuery;
+        }
+
+        $languageFromLocale = explode('_', get_locale())[0] ?? '';
+
+        if ($this->isValidLanguage($languageFromLocale)) {
+            /** @psalm-var LanguageCodes $languageFromLocale */
+            return $languageFromLocale;
+        }
+
+        return MultilingualString::DE;
+    }
+
+    private function isValidLanguage(?string $languageCode): bool
+    {
+        return in_array(
+            $languageCode,
+            [MultilingualString::DE, MultilingualString::EN],
+            true
+        );
     }
 
     public function searchKeyword(): string

--- a/templates/search/item-preview.php
+++ b/templates/search/item-preview.php
@@ -45,7 +45,7 @@ $titleId = sprintf('degree-program-title-%d', $degreeProgram->id());
     <div class="c-degree-program-preview__title">
         <a
             class="c-degree-program-preview__link"
-            href="<?= esc_url($degreeProgram->link()) ?>"
+            href="<?= esc_url($degreeProgram->linkWithLang()) ?>"
             rel="bookmark"
             aria-labelledby="<?= esc_attr($titleId) ?>"
         ></a>

--- a/templates/search/item-preview.php
+++ b/templates/search/item-preview.php
@@ -45,7 +45,7 @@ $titleId = sprintf('degree-program-title-%d', $degreeProgram->id());
     <div class="c-degree-program-preview__title">
         <a
             class="c-degree-program-preview__link"
-            href="<?= esc_url($degreeProgram->linkWithLang()) ?>"
+            href="<?= esc_url($degreeProgram->link()) ?>"
             rel="bookmark"
             aria-labelledby="<?= esc_attr($titleId) ?>"
         ></a>

--- a/templates/search/search.php
+++ b/templates/search/search.php
@@ -42,6 +42,7 @@ use function Fau\DegreeProgram\Output\renderComponent;
 <section
         class="c-degree-programs-search"
         lang="<?= esc_attr(get_bloginfo('language')) ?>"
+        data-locale-switched="<?= is_locale_switched() ? 'true' : 'false' ?>"
         aria-labelledby="degree-programs-search-title"
 >
     <?php if ($hiddenElements->isTitleVisible()) : ?>

--- a/templates/search/search.php
+++ b/templates/search/search.php
@@ -42,7 +42,7 @@ use function Fau\DegreeProgram\Output\renderComponent;
 <section
         class="c-degree-programs-search"
         lang="<?= esc_attr(get_bloginfo('language')) ?>"
-        data-locale-switched="<?= is_locale_switched() ? 'true' : 'false' ?>"
+        data-locale-switched="<?= esc_attr((string) json_encode(is_locale_switched())) ?>"
         aria-labelledby="degree-programs-search-title"
 >
     <?php if ($hiddenElements->isTitleVisible()) : ?>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-452?focusedCommentId=319860


**What is the new behavior (if this is a feature change)?**
We now add the `lang` parameter to the single degree program URL in the search shortcode and use it when rendering the view.
Note: the `lang` parameter is always added. Since it can be used only when needed, I don’t see any benefits in making it optional, as it would only complicate the code. The canonical URL points to the original degree program based on the site's language, ensuring no impact on SEO.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Psalm check fails because this [PR](https://github.com/RRZE-Webteam/FAU-Studium-Common/pull/23) has not been merged yet.