### PR TITLE
[FAU-455] Use custom HTML sanitizer for degree program description

### DIFF
--- a/resources/ts/filters/filters-reset.ts
+++ b/resources/ts/filters/filters-reset.ts
@@ -3,7 +3,7 @@ import { clearActiveFilters } from './active-filters';
 
 const CLEAR_FILTERS_SELECTOR = '.c-active-search-filters__clear-all-button';
 
-const clearFilters = form.querySelector< HTMLElement >(
+const clearFilters = form?.querySelector< HTMLElement >(
 	CLEAR_FILTERS_SELECTOR
 );
 clearFilters?.addEventListener( 'click', ( e ) => {

--- a/templates/single-degree-program/about.php
+++ b/templates/single-degree-program/about.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Fau\DegreeProgram\Common\Application\DegreeProgramViewTranslated;
+use Fau\DegreeProgram\Common\Domain\DegreeProgramSanitizer;
 
 /**
  * @var array{view: DegreeProgramViewTranslated} $data
@@ -20,5 +21,8 @@ if (!$view->content()->about()->description()) {
 
 <div class="c-single-degree-program__about h-post-content l-container">
     <h2><?= esc_html($view->content()->about()->title()) ?></h2>
-    <?= wp_kses_post($view->content()->about()->description()) ?>
+    <?= wp_kses(
+        $view->content()->about()->description(),
+        DegreeProgramSanitizer::ALLOWED_ENTITIES,
+    ) ?>
 </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


**What is the current behavior?** (You can also link to an open issue here)
https://inpsyde.atlassian.net/browse/FAU-455


**What is the new behavior (if this is a feature change)?**
Replaced the generic `wp_kses_post()` with `wp_kses()` and a custom list of allowed tags. The elements are now rendered properly:

<img width="1241" alt="Screenshot 2025-05-16 at 11 40 56" src="https://github.com/user-attachments/assets/f62aac8d-42a7-4dfd-b622-897f5d355d93" />


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
Fixed a minor issue with the form that I noticed while working on this ticket. 